### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,20 +2,20 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ArduinoPebbleSerial KEYWORD1
-Baud                KEYWORD1
-RequestType         KEYWORD1
+ArduinoPebbleSerial	KEYWORD1
+Baud	KEYWORD1
+RequestType	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin_hardware      KEYWORD2
-begin_software      KEYWORD2
-feed                KEYWORD2
-write               KEYWORD2
-notify              KEYWORD2
-is_connected        KEYWORD2
+begin_hardware	KEYWORD2
+begin_software	KEYWORD2
+feed	KEYWORD2
+write	KEYWORD2
+notify	KEYWORD2
+is_connected	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords